### PR TITLE
Update deployment version in XIB

### DIFF
--- a/Demo/Resources/English.lproj/MainMenu.xib
+++ b/Demo/Resources/English.lproj/MainMenu.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="8.00">
 	<data>
-		<int key="IBDocument.SystemTarget">1050</int>
+		<int key="IBDocument.SystemTarget">1070</int>
 		<string key="IBDocument.SystemVersion">14B25</string>
 		<string key="IBDocument.InterfaceBuilderVersion">6254</string>
 		<string key="IBDocument.AppKitVersion">1343.16</string>


### PR DESCRIPTION
This will allow the Demo app to compile on the latest Xcode. Otherwise, the error given is:

:-1: Compiling for earlier than macOS 10.6 is no longer supported. [12]

PS. Thank you for making and sharing this. An NSView-based status indicator is the only option for use in custom NSMenu views due to [a 3-year-old bug in Cocoa](https://stackoverflow.com/questions/26851306/trouble-matching-the-vibrant-background-of-a-yosemite-nsmenuitem-containing-a-cu) with vibrant views and layer-backed views in NSMenu.